### PR TITLE
Only close identical previous ticket

### DIFF
--- a/.github/workflows/recurring_tasks_annual.yml
+++ b/.github/workflows/recurring_tasks_annual.yml
@@ -18,6 +18,7 @@ jobs:
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
               --label "$LABELS" \
+              --json search "$TITLE" \
               --json number \
               --jq '.[0].number')
             if [[ -n $previous_issue_number ]]; then
@@ -53,6 +54,7 @@ jobs:
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
               --label "$LABELS" \
+              --json search "$TITLE" \
               --json number \
               --jq '.[0].number')
             if [[ -n $previous_issue_number ]]; then

--- a/.github/workflows/recurring_tasks_monthly.yml
+++ b/.github/workflows/recurring_tasks_monthly.yml
@@ -18,6 +18,7 @@ jobs:
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
               --label "$LABELS" \
+              --json search "$TITLE" \
               --json number \
               --jq '.[0].number')
             if [[ -n $previous_issue_number ]]; then
@@ -53,6 +54,7 @@ jobs:
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
               --label "$LABELS" \
+              --json search "$TITLE" \
               --json number \
               --jq '.[0].number')
             if [[ -n $previous_issue_number ]]; then

--- a/.github/workflows/recurring_tasks_quarterly.yml
+++ b/.github/workflows/recurring_tasks_quarterly.yml
@@ -18,6 +18,7 @@ jobs:
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
               --label "$LABELS" \
+              --json search "$TITLE" \
               --json number \
               --jq '.[0].number')
             if [[ -n $previous_issue_number ]]; then
@@ -53,6 +54,7 @@ jobs:
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
               --label "$LABELS" \
+              --json search "$TITLE" \
               --json number \
               --jq '.[0].number')
             if [[ -n $previous_issue_number ]]; then
@@ -89,6 +91,7 @@ jobs:
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
               --label "$LABELS" \
+              --json search "$TITLE" \
               --json number \
               --jq '.[0].number')
             if [[ -n $previous_issue_number ]]; then
@@ -125,6 +128,7 @@ jobs:
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
               --label "$LABELS" \
+              --json search "$TITLE" \
               --json number \
               --jq '.[0].number')
             if [[ -n $previous_issue_number ]]; then

--- a/.github/workflows/recurring_tasks_sprint.yml
+++ b/.github/workflows/recurring_tasks_sprint.yml
@@ -47,6 +47,7 @@ jobs:
           if [[ $CLOSE_PREVIOUS == true ]]; then
             previous_issue_number=$(gh issue list \
               --label "$LABELS" \
+              --json search "$TITLE" \
               --json number \
               --jq '.[0].number')
             if [[ -n $previous_issue_number ]]; then


### PR DESCRIPTION
The automated ticket generation is a little too aggressive about closing "previous" tickets. I think the ones set to do so were closing whatever preceeding ticket had a 'maintenance' label. I've (hopefully) set it to close previous tickets with the same title only